### PR TITLE
internal/*/go.mod - add domain to module name

### DIFF
--- a/internal/generator/go.mod
+++ b/internal/generator/go.mod
@@ -1,4 +1,4 @@
-module generator
+module github.com/andrewkroh/go-ingest-node/internal/generator
 
 go 1.23
 

--- a/internal/generator/internal/codegen/generator.go
+++ b/internal/generator/internal/codegen/generator.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"unicode"
 
-	"generator/internal/spec"
+	"github.com/andrewkroh/go-ingest-node/internal/generator/internal/spec"
 
 	"github.com/dave/jennifer/jen"
 	"github.com/elastic/go-licenser/licensing"

--- a/internal/generator/main.go
+++ b/internal/generator/main.go
@@ -25,8 +25,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"generator/internal/codegen"
-	"generator/internal/spec"
+	"github.com/andrewkroh/go-ingest-node/internal/generator/internal/codegen"
+	"github.com/andrewkroh/go-ingest-node/internal/generator/internal/spec"
 )
 
 func main() {

--- a/internal/jsonschema/go.mod
+++ b/internal/jsonschema/go.mod
@@ -1,4 +1,4 @@
-module jsonschema
+module github.com/andrewkroh/go-ingest-node/internal/jsonschema
 
 go 1.23
 


### PR DESCRIPTION
Add domain module name to avoid gofumpt thinking they are stdlib imports.